### PR TITLE
fix: close mobile nav when nested links clicked

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -109,8 +109,9 @@ document.addEventListener('DOMContentLoaded', function(){
     if(!nav) return;
     if(nav.classList.contains('open')){
       var inside = nav.contains(e.target) || (btn && btn.contains(e.target));
+      var link = e.target.closest ? e.target.closest('a') : null;
       if(!inside) closeNav();
-      if(e.target.tagName==='A') closeNav();
+      else if(link) closeNav();
     }
   });
   document.addEventListener('keydown', function(e){ if(e.key==='Escape') closeNav(); });


### PR DESCRIPTION
## Summary
- Ensure mobile navigation closes when clicking on nested elements inside links

## Testing
- `node --check assets/js/app.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a523fcef50832689c94e0b0cce4df8