### PR TITLE
Respect system theme preference by default

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,7 +3,7 @@
 (function(){
   try{
     var saved = localStorage.getItem('cmai_theme');
-    var v = saved ? saved : 'dark';
+    var v = saved || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
     if(v === 'system'){ document.documentElement.removeAttribute('data-theme'); }
     else { document.documentElement.setAttribute('data-theme', v); }
   }catch(e){}
@@ -90,7 +90,7 @@ document.addEventListener('DOMContentLoaded', function(){
   var sel=document.getElementById('themeSelect');
   if(sel){
     try{
-      var saved=localStorage.getItem('cmai_theme')||'dark';
+      var saved=localStorage.getItem('cmai_theme')||'system';
       sel.value=saved;
       sel.addEventListener('change', function(e){
         var v=e.target.value; localStorage.setItem('cmai_theme', v);

--- a/biographies.html
+++ b/biographies.html
@@ -72,9 +72,9 @@
       <div style="margin-top:8px">
         <label for="themeSelect"><small class="muted">Theme</small></label><br>
         <select id="themeSelect" class="theme-select" aria-label="Theme select">
-          <option value="system">System</option>
+          <option value="system" selected>System</option>
           <option value="light">Light</option>
-          <option value="dark" selected>Dark</option>
+          <option value="dark">Dark</option>
         </select>
       </div>
     </div>

--- a/curriculum.html
+++ b/curriculum.html
@@ -160,9 +160,9 @@
       <div style="margin-top:8px">
         <label for="themeSelect"><small class="muted">Theme</small></label><br>
         <select id="themeSelect" class="theme-select" aria-label="Theme select">
-          <option value="system">System</option>
+          <option value="system" selected>System</option>
           <option value="light">Light</option>
-          <option value="dark" selected>Dark</option>
+          <option value="dark">Dark</option>
         </select>
       </div>
     </div>

--- a/events.html
+++ b/events.html
@@ -72,9 +72,9 @@
       <div style="margin-top:8px">
         <label for="themeSelect"><small class="muted">Theme</small></label><br>
         <select id="themeSelect" class="theme-select" aria-label="Theme select">
-          <option value="system">System</option>
+          <option value="system" selected>System</option>
           <option value="light">Light</option>
-          <option value="dark" selected>Dark</option>
+          <option value="dark">Dark</option>
         </select>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -99,9 +99,9 @@
       <div style="margin-top:8px">
         <label for="themeSelect"><small class="muted">Theme</small></label><br>
         <select id="themeSelect" class="theme-select" aria-label="Theme select">
-          <option value="system">System</option>
+          <option value="system" selected>System</option>
           <option value="light">Light</option>
-          <option value="dark" selected>Dark</option>
+          <option value="dark">Dark</option>
         </select>
       </div>
     </div>

--- a/join.html
+++ b/join.html
@@ -98,9 +98,9 @@
       <div style="margin-top:8px">
         <label for="themeSelect"><small class="muted">Theme</small></label><br>
         <select id="themeSelect" class="theme-select" aria-label="Theme select">
-          <option value="system">System</option>
+          <option value="system" selected>System</option>
           <option value="light">Light</option>
-          <option value="dark" selected>Dark</option>
+          <option value="dark">Dark</option>
         </select>
       </div>
     </div>

--- a/programs.html
+++ b/programs.html
@@ -136,9 +136,9 @@
       <div style="margin-top:8px">
         <label for="themeSelect"><small class="muted">Theme</small></label><br>
         <select id="themeSelect" class="theme-select" aria-label="Theme select">
-          <option value="system">System</option>
+          <option value="system" selected>System</option>
           <option value="light">Light</option>
-          <option value="dark" selected>Dark</option>
+          <option value="dark">Dark</option>
         </select>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Default theme now follows the user's system preference when no theme is stored
- Theme selector defaults to **System** on all pages

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a52f7d6ea4832694ab40148858d8a9